### PR TITLE
fix: Fixing issue with interface visibility

### DIFF
--- a/sskr/java/src/main/java/com/bc/sskr/RandomFunc.java
+++ b/sskr/java/src/main/java/com/bc/sskr/RandomFunc.java
@@ -1,5 +1,5 @@
 package com.bc.sskr;
 
-interface RandomFunc {
+public interface RandomFunc {
     byte[] random(int len);
 }


### PR DESCRIPTION
Fixing issue https://github.com/BlockchainCommons/bc-libs-java/issues/4 with interface visibility. If this interface is not public, when making use of the library, it will crash with the following message:
`java.lang.IllegalAccessError: Interface com.bc.sskr.RandomFunc implemented by class [clazz] is inaccessible`

Test passes
> [RemoteAndroidTest]: Running am instrument -w -r   -e additionalTestOutputDir /storage/1C15-0D0E/Android/data/com.bc.sskr.test/files/test_data com.bc.sskr.test/androidx.test.runner.AndroidJUnitRunner on emulator-5554 - 11
> Starting 2 tests on emulator-5554 - 11
> com.bc.sskr.SSKRTest > testSSKRError[emulator-5554 - 11] SUCCESS 
> com.bc.sskr.SSKRTest > testSSKRValidFlow[emulator-5554 - 11] SUCCESS 
